### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage:  `./install.sh`  **[OPTIONS...]**
 
 #### OPTION: -c/--color
 
-Supported colors:  `default` `black` `blue` `brown` `green` `grey` `orange`
+Supported colors:  `standard` `black` `blue` `brown` `green` `grey` `orange`
 `pink` `purple` `red` `yellow`
 
 ## Preview


### PR DESCRIPTION
With the latest version of this repository, there is no `default` colour variation for the icons.

```shell
~/githubs/Tela-icon-theme
❯ ./install.sh --help
Usage: ./install.sh [OPTIONS...]

OPTIONS:
  -d, --dest DIR           Specify theme destination directory (Default: /home/manuel/.local/share/icons)
  -n, --name NAME          Specify theme name (Default: Tela)
  -c, --color VARIANTS...  Specify theme color variant(s) [standard|red|pink|purple|blue|green|yellow|orange|brown|grey|black] (Default: All variants)
  -h, --help               Show this help
```