### PR TITLE
Removed extra shift when -d or -n arguments are used

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,10 +116,10 @@ while [ $# -gt 0 ]; do
     colors=("${COLOR_VARIANTS[@]}")
   elif [[ "$1" = "-d" ]]; then
     DEST_DIR="$2"
-    shift 2
+    shift
   elif [[ "$1" = "-n" ]]; then
     NAME="$2"
-    shift 2
+    shift
   elif [[ "$1" = "-h" ]]; then
     usage
     exit 0


### PR DESCRIPTION
Removed extra `shift` in `install` script for both `-d` and `-n`