### PR TITLE
install.sh: update shebang to be more portable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ${UID} -eq 0 ]; then
   DEST_DIR="/usr/share/icons"


### PR DESCRIPTION
`/bin/bash` doesn't exist on some systems like [NixOS][0].

[0]: https://nixos.org