### PR TITLE
New Sublime Text icon

### DIFF
--- a/src/scalable/apps/sublime-text.svg
+++ b/src/scalable/apps/sublime-text.svg
@@ -1,30 +1,90 @@
-<svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg">
- <circle cx="32" cy="32" r="27" color="#000000" fill="#21252d" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="32" cy="32" r="22" fill="#fff" opacity=".1" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
- <g opacity=".5">
-  <path d="m23.545 19.211h5.96v2.546h-5.96z" display="block" fill="#869eb6" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m29.684 19.5h3.467v2.311h-3.467z" display="block" fill="#8e9f81" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="M23.545 23.454h5.96V26h-5.96z" display="block" fill="#9e9e86" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="M30.334 23.454h3.394V26h-3.394z" display="block" fill="#86b1d6" fill-opacity=".357" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="M34.577 23.454h3.395V26h-3.395z" display="block" fill="#88885e" fill-opacity=".495" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m23.545 27.697h5.96v2.546h-5.96z" display="block" fill="#987f95" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m30.334 27.697h4.243v2.546h-4.243z" display="block" fill="#9d875f" fill-opacity=".687" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m23.545 36.183h5.94v2.546h-5.94z" display="block" fill="#987f95" fill-opacity=".676" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m30.334 36.183h5.78v2.546h-5.78z" display="block" fill="#68798d" fill-opacity=".764" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m37.123 36.183h5.94v2.546h-5.94z" display="block" fill="#606d78" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m43.912 36.183h4.243v2.546h-4.243z" display="block" fill="#8f6094" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m23.545 40.427h5.96v2.545h-5.96z" display="block" fill="#b36b75" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m30.334 40.427h3.394v2.26h-3.394z" display="block" fill="#b47f70" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m23.545 46.367h6.789v2.546h-6.789z" display="block" fill="#53c290" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m31.183 46.367h4.243v2.546h-4.243z" display="block" fill="#e675d2" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m34.577 40.427h3.395v2.545h-3.395z" display="block" fill="#5e6974" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m37.773 42.034h5.2v2.31h-5.2z" display="block" fill="#4d854d" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m33.728 19.5h5.779v2.311h-5.78z" display="block" fill="#b36b75" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m40.085 19.5h5.778v2.311h-5.78z" display="block" fill="#8f6094" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="M18.453 19.211H21v2.546h-2.546zm0 4.243H21V26h-2.546zm0 4.243H21v2.546h-2.546zm0 4.243H21v2.546h-2.546zm0 4.243H21v2.546h-2.546zm0 4.244H21v2.545h-2.546zm0 5.94H21v2.546h-2.546z" display="block" fill="#575f70" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m23.545 14.968h5.94v2.546h-5.94z" display="block" fill="#9176e2" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="m30.334 14.968h3.394v2.546h-3.394z" display="block" fill="#57bdff" fill-opacity=".824" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
-  <path d="M18.453 14.968H21v2.546h-2.546z" display="block" fill="#575f70" overflow="visible" style="isolation:auto;mix-blend-mode:normal"/>
- </g>
- <path d="M37.992 38.211q0-1.835-1.395-2.837-1.368-1.027-4.817-1.76-3.424-.735-5.453-1.762-2.006-1.026-2.984-2.445-.953-1.418-.953-3.374 0-3.253 2.738-5.503 2.763-2.25 7.044-2.25 4.5 0 7.287 2.323 2.812 2.324 2.812 5.943h-4.548q0-1.859-1.59-3.204-1.565-1.345-3.961-1.345-2.47 0-3.865 1.076-1.393 1.076-1.393 2.813 0 1.638 1.296 2.47 1.295.83 4.67 1.589 3.4.758 5.503 1.81 2.103 1.051 3.106 2.543 1.027 1.467 1.027 3.595 0 3.545-2.837 5.697-2.836 2.13-7.361 2.13-3.18 0-5.625-1.126-2.445-1.125-3.839-3.13-1.37-2.03-1.37-4.377h4.525q.122 2.274 1.81 3.619 1.711 1.32 4.499 1.32 2.568 0 4.109-1.026 1.565-1.053 1.565-2.788z" fill="#fff" font-family="Roboto" font-size="83.863" font-weight="400" letter-spacing="0" word-spacing="0"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="26.6 26.6 5.71904 5.720048"
+   width="32"
+   height="32"
+   version="1.1"
+   id="svg15"
+   sodipodi:docname="sublime-text3.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs19">
+    <linearGradient
+       id="linearGradient14128"
+       gradientUnits="userSpaceOnUse"
+       x1="136.17799"
+       x2="372.681"
+       y1="369.638"
+       y2="287.81"
+       gradientTransform="matrix(0.0108019,0,0,0.01080432,26.312669,26.312605)">
+      <stop
+         offset=".233"
+         stop-color="#f89822"
+         id="stop2-3" />
+      <stop
+         offset="1"
+         stop-color="#c27818"
+         id="stop4-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="namedview17"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="5"
+     inkscape:cx="92.4"
+     inkscape:cy="-0.4"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg15" />
+  <linearGradient
+     id="a"
+     gradientUnits="userSpaceOnUse"
+     x1="136.17799"
+     x2="372.681"
+     y1="369.638"
+     y2="287.81"
+     gradientTransform="matrix(0.0108019,0,0,0.01080432,26.759044,26.759484)">
+    <stop
+       offset=".233"
+       stop-color="#f89822"
+       id="stop2" />
+    <stop
+       offset="1"
+       stop-color="#c27818"
+       id="stop4" />
+  </linearGradient>
+  <path
+     d="m 31.685793,31.87317 h -4.452545 c -0.102618,0 -0.186873,-0.08427 -0.186873,-0.186915 v -4.452461 c 0,-0.102641 0.08425,-0.186915 0.186873,-0.186915 h 4.452545 c 0.102618,0 0.186873,0.08427 0.186873,0.186915 v 4.453541 c -0.0011,0.102641 -0.08425,0.185835 -0.186873,0.185835 z"
+     fill="#4d4d4e"
+     id="path7"
+     style="stroke-width:0.0108031" />
+  <path
+     d="m 28.158971,28.504382 2.525485,-0.801681 c 0,0 0.179312,-0.094 0.136104,0.07995 l 0.0065,0.772509 c 0,0 0.03133,0.113446 -0.124222,0.141537 l -1.02618,0.320888 z"
+     fill="#f89820"
+     id="path9"
+     style="stroke-width:0.0108031" />
+  <path
+     d="m 28.158971,28.504382 c 0,0 -0.09938,0.02377 -0.07021,0.193397 l -0.0054,0.744418 c 0,0 -0.0086,0.094 0.16959,0.131813 l 2.502801,0.806002 c 0,0 0.08426,0.03349 0.07453,-0.07023 l 0.0011,-0.829772 c 0,0 0.02376,-0.08535 -0.131783,-0.141536 l -1.02296,-0.320889 z"
+     fill="#f89820"
+     id="path11"
+     style="stroke-width:0.0108031" />
+  <path
+     d="m 29.261845,29.89814 -1.065067,0.32521 c 0,0 -0.128543,0.0043 -0.11342,0.245258 0.01512,0.240936 -0.0011,0.72605 -0.0011,0.72605 0,0 0.0108,0.08968 0.133943,0.03781 l 2.525485,-0.806002 c 0,0 0.08966,-0.02269 0.01404,-0.04754 -0.07561,-0.02377 -1.493904,-0.480792 -1.493904,-0.480792 z"
+     fill="url(#a)"
+     id="path13"
+     style="fill:url(#a);stroke-width:0.0108031" />
 </svg>


### PR DESCRIPTION
Replace Sublime Text icon to match its original logo

New icon:
<img alt="" width="230" src="https://user-images.githubusercontent.com/4531801/187089857-d501d42f-46ff-47f4-96e0-e944c4dca092.svg">

Current icon:
<img alt="" width="230" src="https://user-images.githubusercontent.com/4531801/187089826-5534fc86-69eb-41e9-a06f-51e7ad7a99a0.svg">
