### PR TITLE
Fix color picker icon not changing color dynamically

### DIFF
--- a/links/scalable/apps/color-pick.svg
+++ b/links/scalable/apps/color-pick.svg
@@ -1,1 +1,1 @@
-gpick.svg
+colorgrab-dynamic.svg

--- a/src/scalable/apps/colorgrab-dynamic.svg
+++ b/src/scalable/apps/colorgrab-dynamic.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- 
+   This icon dynamically changes color based on the color of the pixel under the cursor. 
+   Taken from  data/icons/scalable/actions/color-pick.svg in the gnome-shell repository
+-->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="5.4116011mm"
+   height="5.1374583mm"
+   viewBox="0 0 5.4116011 5.1374583"
+   version="1.1"
+   id="svg5595"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="color-pick.svg">
+  <defs
+     id="defs5589">
+    <filter
+       inkscape:collect="always"
+       x="-0.10291173"
+       width="1.2058235"
+       y="-0.065432459"
+       height="1.1308649"
+       id="filter5601"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.610872"
+         id="feGaussianBlur5603" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="39.387731"
+     inkscape:cy="12.554326"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5592">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-103.12753,-146.26461)">
+    <circle
+       r="8.4810486"
+       cy="9.82623"
+       cx="10.226647"
+       id="circle7584"
+       style="color:#000000;display:inline;overflow:visible;opacity:0.6;vector-effect:none;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;filter:url(#filter5601)"
+       transform="matrix(0.26458333,0,0,0.26458333,103.12753,146.26461)" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.26399338;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 108.07728,148.64122 c 0,1.2393 -1.00465,2.24394 -2.24395,2.24394 -1.23929,0 -2.24716,-1.00465 -2.25221,-2.24394 l -0.009,-2.24458 2.26136,6.4e-4 c 1.2393,3.4e-4 2.24395,1.00464 2.24395,2.24394 z"
+       id="path7523-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssscss" />
+    <circle
+       style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#50dbb5;fill-opacity:1;stroke:none;stroke-width:0.36885914;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="path7482-1"
+       cx="105.83707"
+       cy="148.64352"
+       r="1.844296" />
+  </g>
+</svg>


### PR DESCRIPTION
When using a color picker, the icon is not changing color based on the pixel under the cursor. I managed to solve it by taking the color-pick.svg used by Gnome (https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/data/icons/scalable/actions/color-pick.svg) and linking it in this repo.
I've tried removing color-pick.svg as a link expecting the icon theme to simply take the default from Gnome, but it doesn't seem to work, that's why I opted to duplicate it here. I don't have much experience with how icon themes work so there might be a better way.

Source from Gnome where it looks for the icon: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/screenshot.js#L2844