### PR TITLE
Fix install.sh skipping the first argument after a `-c`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -269,7 +269,6 @@ while [ $# -gt 0 ]; do
   elif [[ "$1" = "-c" ]]; then
     colorscheme="true"
     echo "Folder color will follow the colorscheme on KDE plasma ..."
-    shift
   elif [[ "$1" = "-d" ]]; then
     DEST_DIR="$2"
     shift


### PR DESCRIPTION
An extra `shift` in the if statement causes it to move forward 2 arguments instead of 1 on the next loop, skipping the next argument.

Example: `./install.sh -c -d '[filepath]'` would shift twice after the `-c` which skips the `-d` and tries to read the filepath as the next argument, causing an unknown argument error.