### PR TITLE
Add symlinks for display.im7.16* needed by newer version of imagemagick

### DIFF
--- a/src/scalable/apps/display.im7.q16.svg
+++ b/src/scalable/apps/display.im7.q16.svg
@@ -1,0 +1,1 @@
+imagemagick.svg

--- a/src/scalable/apps/display.im7.q16hdri.svg
+++ b/src/scalable/apps/display.im7.q16hdri.svg
@@ -1,0 +1,1 @@
+imagemagick.svg


### PR DESCRIPTION
these are needed for ImageMagick 7