### PR TITLE
feat: add symlink for librewolf-bin

### DIFF
--- a/links/scalable/apps/librewolf-bin.svg
+++ b/links/scalable/apps/librewolf-bin.svg
@@ -1,0 +1,1 @@
+librewolf.svg


### PR DESCRIPTION
Same as the the `firefox-bin.svg -> firefox.svg` link. 